### PR TITLE
MCMC bounds

### DIFF
--- a/inference/mcmc/ensemble.py
+++ b/inference/mcmc/ensemble.py
@@ -34,9 +34,10 @@ class EnsembleSampler(MarkovChain):
         ``alpha`` must be greater than 1, as the jump distance becomes
         zero when ``alpha = 1``.
 
-    :param parameter_boundaries: \
-        A list of length-2 tuples specifying the lower and upper bounds to be set on
-        each parameter, in the form (lower, upper).
+    :param bounds: \
+        An instance of the ``inference.mcmc.Bounds`` class, or a sequence of two
+        ``numpy.ndarray`` specifying the upper and lower bounds for the parameters
+        in the form ``(lower_bounds, upper_bounds)``.
 
     :param bool display_progress: \
         If set as ``True``, a message is displayed during sampling
@@ -48,7 +49,7 @@ class EnsembleSampler(MarkovChain):
         posterior: callable,
         starting_positions: ndarray,
         alpha: float = 2.0,
-        parameter_boundaries: Sequence = None,
+        bounds: Bounds = None,
         display_progress=True,
     ):
         self.posterior = posterior
@@ -69,25 +70,20 @@ class EnsembleSampler(MarkovChain):
             self.total_proposals = [[] for _ in range(self.n_walkers)]
             self.failed_updates = []
 
-        if parameter_boundaries is not None:
-            if len(parameter_boundaries) == self.n_parameters:
-                self.bounds = Bounds(
-                    lower=array([k[0] for k in parameter_boundaries]),
-                    upper=array([k[1] for k in parameter_boundaries]),
-                    error_source="EnsembleSampler",
-                )
-                self.process_proposal = self.bounds.reflect
-            else:
-                raise ValueError(
-                    f"""\n
-                    \r[ EnsembleSampler error ]
-                    \r>> The number of given lower/upper bounds pairs does not match
-                    \r>> the number of model parameters.
-                    """
-                )
-        else:
+        if bounds is None:
             self.process_proposal = self.pass_through
             self.bounds = None
+        else:
+            if isinstance(bounds, Bounds):
+                self.bounds = bounds
+            else:
+                self.bounds = Bounds(
+                    lower=bounds[0],
+                    upper=bounds[1],
+                    error_source="EnsembleSampler",
+                )
+            self.bounds.validate_start_point()
+            self.process_proposal = self.bounds.reflect
 
         # proposal settings
         if not alpha > 1.0:
@@ -387,7 +383,7 @@ class EnsembleSampler(MarkovChain):
         sampler = cls(
             posterior=posterior,
             starting_positions=None,
-            parameter_boundaries=bounds,
+            bounds=bounds,
             alpha=D["alpha"],
             display_progress=bool(D["display_progress"]),
         )

--- a/inference/mcmc/ensemble.py
+++ b/inference/mcmc/ensemble.py
@@ -82,7 +82,7 @@ class EnsembleSampler(MarkovChain):
                     error_source="EnsembleSampler",
                 )
             # check the starting positions are inside the bounds
-            if self.walker_positions is not None:
+            if hasattr(self, "walker_positions"):
                 for v in self.walker_positions:
                     self.bounds.validate_start_point(v, error_source="EnsembleSampler")
 

--- a/inference/mcmc/hmc.py
+++ b/inference/mcmc/hmc.py
@@ -1,4 +1,3 @@
-from typing import Sequence
 from copy import copy
 import matplotlib.pyplot as plt
 
@@ -48,7 +47,7 @@ class HamiltonianChain(MarkovChain):
 
     :param bounds: \
         An instance of the ``inference.mcmc.Bounds`` class, or a sequence of two
-        ``numpy.ndarray`` specifying the upper and lower bounds for the parameters
+        ``numpy.ndarray`` specifying the lower and upper bounds for the parameters
         in the form ``(lower_bounds, upper_bounds)``.
 
     :param inverse_mass: \
@@ -107,7 +106,8 @@ class HamiltonianChain(MarkovChain):
                     lower=bounds[0], upper=bounds[1], error_source="HamiltonianChain"
                 )
 
-            self.bounds.validate_start_point(start, error_source="HamiltonianChain")
+            if start is not None:
+                self.bounds.validate_start_point(start, error_source="HamiltonianChain")
 
         self.max_attempts = 200
         self.ES = EpsilonSelector(epsilon)
@@ -400,7 +400,7 @@ class HamiltonianChain(MarkovChain):
         }
         if self.bounds is not None:
             items.update(
-                {"lwr_bounds": self.bounds.lower, "upr_bounds": self.bounds.upper}
+                {"lower_bounds": self.bounds.lower, "upper_bounds": self.bounds.upper}
             )
         items.update(self.ES.get_items())
 
@@ -414,8 +414,12 @@ class HamiltonianChain(MarkovChain):
     def load(cls, filename: str, posterior=None, grad=None):
         D = load(filename)
 
-        if "lwr_bounds" in D and "upr_bounds" in D:
-            bounds = [D["lwr_bounds"], D["upr_bounds"]]
+        if all(k in D for k in ["lower_bounds", "upper_bounds"]):
+            bounds = Bounds(
+                lower=D["lower_bounds"],
+                upper=D["upper_bounds"],
+                error_source="HamiltonianChain",
+            )
         else:
             bounds = None
 

--- a/inference/mcmc/pca.py
+++ b/inference/mcmc/pca.py
@@ -8,6 +8,7 @@ from numpy.random import random, normal
 from scipy.linalg import eigh
 
 from inference.mcmc.gibbs import MetropolisChain, Parameter
+from inference.mcmc.utilities import Bounds
 
 
 class PcaChain(MetropolisChain):
@@ -40,16 +41,17 @@ class PcaChain(MetropolisChain):
         the proposal distribution for each model parameter. If not specified, the starting
         widths will be approximated as 5% of the values in 'start'.
 
-    :param parameter_boundaries: \
-        A list of length-2 tuples specifying the lower and upper bounds to be set on each
-        parameter, in the form (lower, upper).
+    :param bounds: \
+        An instance of the ``inference.mcmc.Bounds`` class, or a sequence of two
+        ``numpy.ndarray`` specifying the upper and lower bounds for the parameters
+        in the form ``(lower_bounds, upper_bounds)``.
 
     :param bool display_progress: \
         If set as ``True``, a message is displayed during sampling
         showing the current progress and an estimated time until completion.
     """
 
-    def __init__(self, *args, parameter_boundaries=None, **kwargs):
+    def __init__(self, *args, bounds=None, **kwargs):
         super(PcaChain, self).__init__(*args, **kwargs)
         # we need to adjust the target acceptance rate to 50%
         # which is optimal for gibbs sampling:
@@ -74,23 +76,17 @@ class PcaChain(MetropolisChain):
         self.angles_history = []
         self.update_history = []
 
-        # Set-up for imposing boundaries if specified
-        if parameter_boundaries is not None:
-            if len(parameter_boundaries) == self.n_parameters:
-                self.lower = array([k[0] for k in parameter_boundaries])
-                self.upper = array([k[1] for k in parameter_boundaries])
-                self.width = self.upper - self.lower
-                self.process_proposal = self.impose_boundaries
-            else:
-                warn(
-                    """
-                    [ PcaChain warning ]
-                    >> The number of given lower/upper bounds pairs does not match
-                    >> the number of model parameters - bounds were not imposed.
-                    """
-                )
-        else:
+        if bounds is None:
             self.process_proposal = self.pass_through
+            self.bounds = None
+        else:
+            self.bounds = Bounds(
+                lower=bounds[0], upper=bounds[1], error_source="PcaChain"
+            )
+            self.process_proposal = self.bounds.reflect
+            self.bounds.validate_start_point(
+                start=self.get_last(), error_source="PcaChain"
+            )
 
     def update_directions(self):
         # re-estimate the covariance and find its eigenvectors

--- a/inference/mcmc/pca.py
+++ b/inference/mcmc/pca.py
@@ -80,13 +80,19 @@ class PcaChain(MetropolisChain):
             self.process_proposal = self.pass_through
             self.bounds = None
         else:
-            self.bounds = Bounds(
-                lower=bounds[0], upper=bounds[1], error_source="PcaChain"
-            )
+            if isinstance(bounds, Bounds):
+                self.bounds = bounds
+            else:
+                self.bounds = Bounds(
+                    lower=bounds[0], upper=bounds[1], error_source="PcaChain"
+                )
+
             self.process_proposal = self.bounds.reflect
-            self.bounds.validate_start_point(
-                start=self.get_last(), error_source="PcaChain"
-            )
+
+            if hasattr(self, "params"):
+                self.bounds.validate_start_point(
+                    start=self.get_last(), error_source="PcaChain"
+                )
 
     def update_directions(self):
         # re-estimate the covariance and find its eigenvectors
@@ -201,9 +207,15 @@ class PcaChain(MetropolisChain):
             "covar": self.covar,
         }
 
+        if self.bounds is not None:
+            items |= {
+                "lower_bounds": self.bounds.lower,
+                "upper_bounds": self.bounds.upper,
+            }
+
         # get the parameter attributes
         for i, p in enumerate(self.params):
-            items.update(p.get_items(param_id=i))
+            items |= p.get_items(param_id=i)
 
         # save as npz
         savez(filename, **items)
@@ -222,10 +234,22 @@ class PcaChain(MetropolisChain):
         """
         # load the data and create a chain instance
         D = load(filename)
+
+        # check if there are bounds to load
+        if all(k in D for k in ["lower_bounds", "upper_bounds"]):
+            bounds = Bounds(
+                lower=D["lower_bounds"],
+                upper=D["upper_bounds"],
+                error_source="PcaChain",
+            )
+        else:
+            bounds = None
+
         chain = cls(
             posterior=None,
             start=None,
             widths=None,
+            bounds=bounds,
             display_progress=bool(D["display_progress"]),
         )
 
@@ -272,11 +296,6 @@ class PcaChain(MetropolisChain):
              the parameter_boundaries keyword argument.
              """
         )
-
-    def impose_boundaries(self, prop):
-        d = prop - self.lower
-        n = (d // self.width) % 2
-        return self.lower + (1 - 2 * n) * (d % self.width) + n * self.width
 
     def pass_through(self, prop):
         return prop

--- a/inference/mcmc/pca.py
+++ b/inference/mcmc/pca.py
@@ -43,7 +43,7 @@ class PcaChain(MetropolisChain):
 
     :param bounds: \
         An instance of the ``inference.mcmc.Bounds`` class, or a sequence of two
-        ``numpy.ndarray`` specifying the upper and lower bounds for the parameters
+        ``numpy.ndarray`` specifying the lower and upper bounds for the parameters
         in the form ``(lower_bounds, upper_bounds)``.
 
     :param bool display_progress: \

--- a/inference/mcmc/utilities.py
+++ b/inference/mcmc/utilities.py
@@ -97,8 +97,8 @@ def effective_sample_size(x: ndarray) -> int:
 
 class Bounds:
     def __init__(self, lower: ndarray, upper: ndarray, error_source="Bounds"):
-        self.lower = lower if isinstance(lower, ndarray) else array(lower)
-        self.upper = upper if isinstance(upper, ndarray) else array(upper)
+        self.lower = lower if isinstance(lower, ndarray) else array(lower).squeeze()
+        self.upper = upper if isinstance(upper, ndarray) else array(upper).squeeze()
 
         if self.lower.ndim > 1 or self.upper.ndim > 1:
             raise ValueError(
@@ -127,6 +127,25 @@ class Bounds:
             )
 
         self.width = self.upper - self.lower
+        self.n_bounds = self.width.size
+
+    def validate_start_point(self, start: ndarray, error_source="Bounds"):
+        if self.n_bounds != start.size:
+            raise ValueError(
+                f"""\n
+                \r[ {error_source} error ]
+                \r>> The number of parameters ({start.size}) does not
+                \r>> match the given number of bounds ({self.n_bounds}).
+                """
+            )
+
+        if not self.inside(start):
+            raise ValueError(
+                f"""\n
+                \r[ {error_source} error ]
+                \r>> Starting location for the chain is outside specified bounds.
+                """
+            )
 
     def reflect(self, theta: ndarray) -> ndarray:
         q, rem = np_divmod(theta - self.lower, self.width)

--- a/tests/mcmc/test_hamiltonian.py
+++ b/tests/mcmc/test_hamiltonian.py
@@ -88,12 +88,12 @@ def test_hamiltonian_chain_advance_bounds(line_posterior):
 
 def test_hamiltonian_chain_restore(tmp_path):
     posterior = ToroidalGaussian()
-    bounds = Bounds(lower=array([-2., -2., -1.]), upper=array([2., 2., 1.]))
+    bounds = Bounds(lower=array([-2.0, -2.0, -1.0]), upper=array([2.0, 2.0, 1.0]))
     chain = HamiltonianChain(
         posterior=posterior,
         start=array([1.0, 0.1, 0.1]),
         grad=posterior.gradient,
-        bounds=bounds
+        bounds=bounds,
     )
     steps = 10
     chain.advance(steps)
@@ -106,8 +106,8 @@ def test_hamiltonian_chain_restore(tmp_path):
     assert new_chain.chain_length == chain.chain_length
     assert new_chain.probs == chain.probs
     assert (new_chain.get_last() == chain.get_last()).all()
-    assert(new_chain.bounds.lower == chain.bounds.lower).all()
-    assert(new_chain.bounds.upper == chain.bounds.upper).all()
+    assert (new_chain.bounds.lower == chain.bounds.lower).all()
+    assert (new_chain.bounds.upper == chain.bounds.upper).all()
 
 
 def test_hamiltonian_chain_plots():

--- a/tests/mcmc/test_hamiltonian.py
+++ b/tests/mcmc/test_hamiltonian.py
@@ -2,7 +2,7 @@ import pytest
 from numpy import array
 from itertools import product
 from mcmc_utils import ToroidalGaussian, line_posterior, sliced_length
-from inference.mcmc import HamiltonianChain
+from inference.mcmc import HamiltonianChain, Bounds
 
 
 def test_hamiltonian_chain_take_step():
@@ -88,8 +88,12 @@ def test_hamiltonian_chain_advance_bounds(line_posterior):
 
 def test_hamiltonian_chain_restore(tmp_path):
     posterior = ToroidalGaussian()
+    bounds = Bounds(lower=array([-2., -2., -1.]), upper=array([2., 2., 1.]))
     chain = HamiltonianChain(
-        posterior=posterior, start=array([1.0, 0.1, 0.1]), grad=posterior.gradient
+        posterior=posterior,
+        start=array([1.0, 0.1, 0.1]),
+        grad=posterior.gradient,
+        bounds=bounds
     )
     steps = 10
     chain.advance(steps)
@@ -102,6 +106,8 @@ def test_hamiltonian_chain_restore(tmp_path):
     assert new_chain.chain_length == chain.chain_length
     assert new_chain.probs == chain.probs
     assert (new_chain.get_last() == chain.get_last()).all()
+    assert(new_chain.bounds.lower == chain.bounds.lower).all()
+    assert(new_chain.bounds.upper == chain.bounds.upper).all()
 
 
 def test_hamiltonian_chain_plots():

--- a/tests/mcmc/test_pca.py
+++ b/tests/mcmc/test_pca.py
@@ -1,6 +1,6 @@
 from numpy import array
 from mcmc_utils import line_posterior
-from inference.mcmc import PcaChain
+from inference.mcmc import PcaChain, Bounds
 
 
 def test_pca_chain_take_step(line_posterior):
@@ -40,7 +40,7 @@ def test_pca_chain_advance_bounded(line_posterior):
 
 
 def test_pca_chain_restore(line_posterior, tmp_path):
-    bounds = [array([0.4, 0.0]), array([0.6, 0.5])]
+    bounds = Bounds(lower=array([0.4, 0.0]), upper=array([0.6, 0.5]))
     chain = PcaChain(posterior=line_posterior, start=[0.5, 0.1], bounds=bounds)
     steps = 200
     chain.advance(steps)
@@ -54,3 +54,5 @@ def test_pca_chain_restore(line_posterior, tmp_path):
     assert new_chain.chain_length == chain.chain_length
     assert new_chain.probs == chain.probs
     assert (new_chain.get_last() == chain.get_last()).all()
+    assert (new_chain.bounds.lower == chain.bounds.lower).all()
+    assert (new_chain.bounds.upper == chain.bounds.upper).all()

--- a/tests/mcmc/test_pca.py
+++ b/tests/mcmc/test_pca.py
@@ -1,3 +1,4 @@
+from numpy import array
 from mcmc_utils import line_posterior
 from inference.mcmc import PcaChain
 
@@ -25,8 +26,22 @@ def test_pca_chain_advance(line_posterior):
     assert len(chain.probs) == chain.chain_length
 
 
+def test_pca_chain_advance_bounded(line_posterior):
+    bounds = [array([0.4, 0.0]), array([0.6, 0.5])]
+    chain = PcaChain(posterior=line_posterior, start=[0.5, 0.1], bounds=bounds)
+    first_n = chain.chain_length
+
+    steps = 104
+    chain.advance(steps)
+
+    assert chain.chain_length == first_n + steps
+    assert len(chain.params[0].samples) == chain.chain_length
+    assert len(chain.probs) == chain.chain_length
+
+
 def test_pca_chain_restore(line_posterior, tmp_path):
-    chain = PcaChain(posterior=line_posterior, start=[0.5, 0.1])
+    bounds = [array([0.4, 0.0]), array([0.6, 0.5])]
+    chain = PcaChain(posterior=line_posterior, start=[0.5, 0.1], bounds=bounds)
     steps = 200
     chain.advance(steps)
 
@@ -38,4 +53,4 @@ def test_pca_chain_restore(line_posterior, tmp_path):
 
     assert new_chain.chain_length == chain.chain_length
     assert new_chain.probs == chain.probs
-    assert all(new_chain.get_last() == chain.get_last())
+    assert (new_chain.get_last() == chain.get_last()).all()


### PR DESCRIPTION
 - Specification of parameter bounds has been standardised across `HamiltonianChain`, `PcaChain` and `EnsembleSampler`. On initialisation they each have an optional `bounds` keyword argument, which takes an instance of `inference.mcmc.Bounds` or a sequence of two `numpy.ndarray`.

 - Validation of the bounds against chain starting positions and number of parameters has been added.