### PR TITLE
Prior abstract base-class

### DIFF
--- a/inference/priors.py
+++ b/inference/priors.py
@@ -107,9 +107,10 @@ class JointPrior(BasePrior):
     def __init__(self, components: list[BasePrior], n_variables: int):
         if not all(isinstance(c, BasePrior) for c in components):
             raise TypeError(
-                """
-                All objects contained in the 'components' argument must be instances
-                of a subclass of BasePrior (e.g. GaussianPrior, UniformPrior)
+                """\n
+                \r[ JointPrior error ]
+                \r>> The sequence of prior objects passed to the 'components' argument 
+                \r>> of 'JointPrior' must be instances of a subclass of 'BasePrior'.
                 """
             )
 
@@ -127,24 +128,31 @@ class JointPrior(BasePrior):
         for var in chain(*[c.variables for c in self.components]):
             if var in self.prior_variables:
                 raise ValueError(
-                    f"Variable index '{var}' appears more than once in prior components"
+                    f"""\n
+                    \r[ JointPrior error ]
+                    \r>> Variable index '{var}' appears more than once in the prior
+                    \r>> objects passed to the 'components' argument of 'JointPrior'.
+                    """
                 )
             self.prior_variables.append(var)
 
         if len(self.prior_variables) != n_variables:
             raise ValueError(
-                f"""
-                The total number of variables specified across the various prior
-                components ({len(self.prior_variables)}) does not match the number specified in
-                the 'n_variables' argument ({n_variables}).
+                f"""\n
+                \r[ JointPrior error ]
+                \r>> The total number of variables specified across the various prior
+                \r>> components ({len(self.prior_variables)}) does not match the number
+                \r>> specified in the 'n_variables' argument ({n_variables}).
                 """
             )
 
         if not all(0 <= i < n_variables for i in self.prior_variables):
             raise ValueError(
-                """
-                All variable indices given to the prior components must have values
-                in the range [0, n_variables-1].
+                """\n
+                \r[ JointPrior error ]
+                \r>> All variable indices specified across the various prior
+                \r>> objects passed to the 'components' argument of 'JointPrior'
+                \r>> must have values in the range [0, n_variables - 1].
                 """
             )
 

--- a/inference/priors.py
+++ b/inference/priors.py
@@ -516,9 +516,9 @@ def attempt_array_conversion(param) -> bool:
     # if input is a zero-dimensional array, we need to convert to 1D
     zero_dim_array = isinstance(param, ndarray) and param.ndim == 0
     # if the input is a float or an int, also convert to a 1D array
-    valid_number = isinstance(param, Union[float, int])
+    valid_number = isinstance(param, (int, float))
     # if the input is a list or tuple containing only floats and ints, also convert
-    valid_sequence = isinstance(param, Union[list, tuple]) and all(
-        isinstance(v, Union[int, float]) for v in param
+    valid_sequence = isinstance(param, (list, tuple)) and all(
+        isinstance(v, (int, float)) for v in param
     )
     return zero_dim_array or valid_sequence or valid_number

--- a/inference/priors.py
+++ b/inference/priors.py
@@ -10,6 +10,8 @@ from itertools import chain
 
 
 class BasePrior(ABC):
+    variables: list[int]
+
     @staticmethod
     def check_variables(variable_inds: Union[int, Iterable[int]], n_vars: int):
         if not isinstance(variable_inds, (int, Iterable)):
@@ -102,7 +104,7 @@ class JointPrior(BasePrior):
         The total number of model variables.
     """
 
-    def __init__(self, components, n_variables: int):
+    def __init__(self, components: list[BasePrior], n_variables: int):
         if not all(isinstance(c, BasePrior) for c in components):
             raise TypeError(
                 """
@@ -203,18 +205,18 @@ class GaussianPrior(BasePrior):
     A class for generating a Gaussian prior for one or more of the model variables.
 
     :param mean: \
-        A list specifying the means of the Gaussian priors on each of the variables specified
-        in the ``variable_indices`` argument.
+        The means of the Gaussian priors on each of the variables specified
+        in the ``variable_indices`` argument as a 1D ``numpy.ndarray``.
 
     :param sigma: \
-        A list specifying the standard deviations of the Gaussian priors on each of the
-        variables specified in the ``variable_indices`` argument.
+        The standard deviations of the Gaussian priors on each of the variables
+        specified in the ``variable_indices`` argument as a 1D ``numpy.ndarray``.
 
     :param variable_indices: \
         A list of integers specifying the indices of the variables to which the prior will apply.
     """
 
-    def __init__(self, mean, sigma, variable_indices: list[int]):
+    def __init__(self, mean: ndarray, sigma: ndarray, variable_indices: list[int]):
         self.mean = array(mean, dtype=float64).squeeze()
         self.sigma = array(sigma, dtype=float64).squeeze()
 
@@ -300,14 +302,14 @@ class ExponentialPrior(BasePrior):
     A class for generating an exponential prior for one or more of the model variables.
 
     :param beta: \
-        A list specifying the 'beta' parameter value of the exponential priors on each of the
-        variables specified in the ``variable_indices`` argument.
+        The 'beta' parameter values of the exponential priors on each of the variables
+        specified in the ``variable_indices`` argument as a 1D ``numpy.ndarray``.
 
     :param variable_indices: \
         A list of integers specifying the indices of the variables to which the prior will apply.
     """
 
-    def __init__(self, beta, variable_indices: list[int]):
+    def __init__(self, beta: ndarray, variable_indices: list[int]):
         self.beta = array(beta, dtype=float64).squeeze()
         if self.beta.ndim == 0:
             self.beta = self.beta.reshape([1])
@@ -364,7 +366,7 @@ class ExponentialPrior(BasePrior):
         return exponential(scale=self.beta)
 
     @classmethod
-    def combine(cls, priors):
+    def combine(cls, priors: list[BasePrior]):
         if not all(isinstance(p, cls) for p in priors):
             raise ValueError(f"All prior objects being combined must be of type {cls}")
 
@@ -381,18 +383,18 @@ class UniformPrior(BasePrior):
     A class for generating a uniform prior for one or more of the model variables.
 
     :param lower: \
-        A list specifying the lower bound of the uniform priors on each of the variables
-        specified in the ``variable_indices`` argument.
+        The lower bound of the uniform priors on each of the variables
+        specified in the ``variable_indices`` argument as a 1D ``numpy.ndarray``.
 
     :param upper: \
-        A list specifying the upper bound of the uniform priors on each of the variables
-        specified in the ``variable_indices`` argument.
+        The upper bound of the uniform priors on each of the variables
+        specified in the ``variable_indices`` argument as a 1D ``numpy.ndarray``.
 
     :param variable_indices: \
         A list of integers specifying the indices of the variables to which the prior will apply.
     """
 
-    def __init__(self, lower, upper, variable_indices: list[int]):
+    def __init__(self, lower: ndarray, upper: ndarray, variable_indices: list[int]):
         self.lower = array(lower).squeeze()
         self.upper = array(upper).squeeze()
 

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -35,7 +35,7 @@ def finite_difference(func=None, x0=None, delta=1e-5, vectorised_arguments=False
 
 @given(variable_inds=st.integers())
 def test_check_variables_scalar(variable_inds):
-    result = BasePrior.check_variables(variable_inds, 1)
+    result = BasePrior.validate_variable_indices(variable_inds, 1)
     assert result == [variable_inds]
 
 
@@ -43,12 +43,12 @@ def test_check_variables_scalar(variable_inds):
 def test_check_variables_scalar_bad(variable_inds, length):
     assume(length != 1)
     with pytest.raises(ValueError):
-        BasePrior.check_variables(variable_inds, length)
+        BasePrior.validate_variable_indices(variable_inds, length)
 
 
 @given(variable_inds=st.lists(st.integers(), unique=True))
 def test_check_variables_list(variable_inds):
-    result = BasePrior.check_variables(variable_inds, len(variable_inds))
+    result = BasePrior.validate_variable_indices(variable_inds, len(variable_inds))
     assert result == variable_inds
 
 
@@ -56,17 +56,17 @@ def test_check_variables_list(variable_inds):
 def test_check_variables_list_bad_length(variable_inds, length):
     assume(length != len(variable_inds))
     with pytest.raises(ValueError):
-        BasePrior.check_variables(variable_inds, length)
+        BasePrior.validate_variable_indices(variable_inds, length)
 
 
 def test_check_variables_list_not_int():
     with pytest.raises(TypeError):
-        BasePrior.check_variables([1, 3, 2.0, 4], 4)
+        BasePrior.validate_variable_indices([1, 3, 2.0, 4], 4)
 
 
 def test_check_variables_list_repeated():
     with pytest.raises(ValueError):
-        BasePrior.check_variables([1, 3, 4, 3], 4)
+        BasePrior.validate_variable_indices([1, 3, 4, 3], 4)
 
 
 def test_GaussianPrior():


### PR DESCRIPTION
 - Converted `BasePrior` from `inference.priors` to an abstract base-class.
 - The expected type for specifying parameter values to prior classes is now `numpy.ndarray`, however they may still be specified as `float`, `int` or a iterable containing only `float` and `int` in order to maintain backward-compatibility.
 - Source code documentation and error messages have been improved throughout the `inference.priors` module.
 - Validation of both parameter values and variable indices passed to prior classes on initialization has been improved.