### PR TITLE
Vectorised HDI calculation

### DIFF
--- a/inference/pdf/hdi.py
+++ b/inference/pdf/hdi.py
@@ -47,7 +47,6 @@ def sample_hdi(sample: ndarray, fraction: float) -> ndarray:
             """
         )
 
-
     if s.ndim > 2 or s.ndim == 0:
         raise ValueError(
             f"""\n

--- a/inference/pdf/hdi.py
+++ b/inference/pdf/hdi.py
@@ -1,11 +1,9 @@
 from _warnings import warn
 from typing import Sequence
-
-from numpy import ndarray, array, sort
-from scipy.optimize import differential_evolution
+from numpy import ndarray, array, sort, zeros, take_along_axis, expand_dims
 
 
-def sample_hdi(sample: ndarray, fraction: float, allow_double=False):
+def sample_hdi(sample: ndarray, fraction: float) -> ndarray:
     """
     Estimate the highest-density interval(s) for a given sample.
 
@@ -13,26 +11,25 @@ def sample_hdi(sample: ndarray, fraction: float, allow_double=False):
     fraction of the elements in the given sample.
 
     :param sample: \
-        A sample for which the interval will be determined.
+        A sample for which the interval will be determined. If the sample is given
+        as a 2D numpy array, the interval calculation will be distributed over the
+        second dimension of the array, i.e. given a sample array of shape ``(m, n)``
+        the highest-density intervals are returned as an array of shape ``(2, n)``.
 
     :param float fraction: \
         The fraction of the total probability to be contained by the interval.
 
-    :param bool allow_double: \
-        When set to True, a double-interval is returned instead if one exists whose
-        total length is meaningfully shorter than the optimal single interval.
-
     :return: \
-        Tuple(s) specifying the lower and upper bounds of the highest-density interval(s).
+        The lower and upper bounds of the highest-density interval(s) as a numpy array.
     """
 
     # verify inputs are valid
     if not 0.0 < fraction < 1.0:
         raise ValueError(
             f"""\n
-            [ sample_hdi error ]
-            >> The 'fraction' argument must be a float between 0 and 1,
-            >> but the value given was {fraction}.
+            \r[ sample_hdi error ]
+            \r>> The 'fraction' argument must be a float between 0 and 1,
+            \r>> but the value given was {fraction}.
             """
         )
 
@@ -43,66 +40,73 @@ def sample_hdi(sample: ndarray, fraction: float, allow_double=False):
     else:
         raise ValueError(
             f"""\n
-            [ sample_hdi error ]
-            >> The 'sample' argument should be a numpy.ndarray or a
-            >> Sequence which can be converted to an array, but
-            >> instead has type {type(sample)}.
+            \r[ sample_hdi error ]
+            \r>> The 'sample' argument should be a numpy.ndarray or a
+            \r>> Sequence which can be converted to an array, but
+            \r>> instead has type {type(sample)}.
             """
         )
 
-    if s.size < 2:
+
+    if s.ndim > 2 or s.ndim == 0:
         raise ValueError(
             f"""\n
-            [ sample_hdi error ]
-            >> The given 'sample' array must contain at least 2 values.
+            \r[ sample_hdi error ]
+            \r>> The 'sample' argument should be a numpy.ndarray
+            \r>> with either one or two dimensions, but the given
+            \r>> array has dimensionality {s.ndim}.
             """
         )
 
-    if s.ndim > 1:
-        s = s.flatten()
-    s.sort()
-    n = s.size
-    L = int(fraction * n)
+    if s.ndim == 1:
+        s.resize([s.size, 1])
+
+    n_samples, n_intervals = s.shape
+    L = int(fraction * n_samples)
+
+    if n_samples < 2:
+        raise ValueError(
+            f"""\n
+            \r[ sample_hdi error ]
+            \r>> The first dimension of the given 'sample' array must 
+            \r>> have have a length of at least 2.
+            """
+        )
 
     # check that we have enough samples to estimate the HDI for the chosen fraction
-    if n <= L:
+    if n_samples <= L:
         warn(
             f"""\n
-            [ sample_hdi warning ]
-            >> The given number of samples is insufficient to estimate the interval
-            >> for the given fraction.
-            """
-        )
-        return s[0], s[-1]
-    elif n - L < 20:
-        warn(
-            f"""\n
-            [ sample_hdi warning ]
-            >> len(sample)*(1 - fraction) is small - calculated interval may be inaccurate.
+            \r[ sample_hdi warning ]
+            \r>> The given number of samples is insufficient to estimate the interval
+            \r>> for the given fraction.
             """
         )
 
-    # find the optimal single HDI
-    widths = s[L:] - s[: n - L]
-    i = widths.argmin()
-    r1, w1 = (s[i], s[i + L]), s[i + L] - s[i]
+    elif n_samples - L < 20:
+        warn(
+            f"""\n
+            \r[ sample_hdi warning ]
+            \r>> n_samples * (1 - fraction) is small - calculated interval may be inaccurate.
+            """
+        )
 
-    if allow_double:
-        # now get the best 2-interval solution
-        minfunc = dbl_interval_length(sample, fraction)
-        bounds = minfunc.get_bounds()
-        de_result = differential_evolution(minfunc, bounds)
-        I1, I2 = minfunc.return_intervals(de_result.x)
-        w2 = (I2[1] - I2[0]) + (I1[1] - I1[0])
-
-    # return the split interval if the width reduction is non-trivial:
-    if allow_double and w2 < w1 * 0.99:
-        return I1, I2
+    # check that we have enough samples to estimate the HDI for the chosen fraction
+    s.sort(axis=0)
+    hdi = zeros([2, n_intervals])
+    if n_samples > L:
+        # find the optimal single HDI
+        widths = s[L:, :] - s[: n_samples - L, :]
+        i = expand_dims(widths.argmin(axis=0), axis=0)
+        hdi[0, :] = take_along_axis(s, i, 0).squeeze()
+        hdi[1, :] = take_along_axis(s, i + L, 0).squeeze()
     else:
-        return r1
+        hdi[0, :] = s[0, :]
+        hdi[1, :] = s[-1, :]
+    return hdi.squeeze()
 
 
-class dbl_interval_length:
+class DoubleIntervalLength:
     def __init__(self, sample, fraction):
         self.sample = sort(sample)
         self.f = fraction

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -4,7 +4,8 @@ from inference.pdf.kde import GaussianKDE, BinaryTree, unique_index_groups
 
 from dataclasses import dataclass
 from numpy.random import default_rng
-from numpy import array, ndarray, arange, isclose, linspace, concatenate, zeros
+from numpy import array, ndarray, arange, linspace, concatenate, zeros
+from numpy import isclose, allclose
 
 import pytest
 from hypothesis import given, strategies as st
@@ -121,20 +122,32 @@ def test_gaussian_kde_plotting():
     assert top >= pdf(expected_mu)
 
 
-def test_sample_hdi_95():
+def test_sample_hdi_gaussian():
     N = 20000
     expected_mu = 5.0
-    expected_sigma = 2.0
-    sample = default_rng(1324).normal(expected_mu, expected_sigma, size=N)
+    expected_sigma = 3.0
+    rng = default_rng(1324)
 
-    left, right = sample_hdi(sample, fraction=0.95)
+    # test for a single sample
+    sample = rng.normal(expected_mu, expected_sigma, size=N)
+    left, right = sample_hdi(sample, fraction=0.9545)
 
     tolerance = 0.2
     assert isclose(
-        left, expected_mu - (expected_sigma**2), rtol=tolerance, atol=tolerance
+        left, expected_mu - 2 * expected_sigma, rtol=tolerance, atol=tolerance
     )
     assert isclose(
-        right, expected_mu + (expected_sigma**2), rtol=tolerance, atol=tolerance
+        right, expected_mu + 2 * expected_sigma, rtol=tolerance, atol=tolerance
+    )
+
+    # test for a multiple samples
+    sample = rng.normal(expected_mu, expected_sigma, size=[N, 3])
+    intervals = sample_hdi(sample, fraction=0.9545)
+    assert allclose(
+        intervals[0, :], expected_mu - 2 * expected_sigma, rtol=tolerance, atol=tolerance
+    )
+    assert allclose(
+        intervals[1, :], expected_mu + 2 * expected_sigma, rtol=tolerance, atol=tolerance
     )
 
 
@@ -156,21 +169,6 @@ def test_sample_hdi_linear(fraction):
     assert isclose(right - left, fraction, rtol=1e-2, atol=1e-2)
 
 
-def test_sample_hdi_double():
-    N = 20000
-    half = linspace(0, 1, N)
-    sample = concatenate((half, 1 - half))
-    fraction = 1e-4
-
-    (left_a, right_a), (left_b, right_b) = sample_hdi(
-        sample, fraction=fraction, allow_double=True
-    )
-    assert left_a <= right_a
-    assert left_b <= right_b
-    assert isclose(right_a - left_a, fraction, rtol=1e-2, atol=1e-2)
-    assert isclose(right_b - left_b, fraction, rtol=1e-2, atol=1e-2)
-
-
 def test_sample_hdi_invalid_fractions():
     # Create some samples from the exponentially-modified Gaussian distribution
     sample = default_rng(1324).normal(size=3000)
@@ -178,10 +176,21 @@ def test_sample_hdi_invalid_fractions():
         sample_hdi(sample, fraction=2.0)
     with pytest.raises(ValueError):
         sample_hdi(sample, fraction=-0.1)
+
+
+def test_sample_hdi_invalid_shapes():
+    rng = default_rng(1324)
+    sample_3D = rng.normal(size=[1000, 2, 2])
     with pytest.raises(ValueError):
-        sample_hdi([1], fraction=0.95)
+        sample_hdi(sample_3D, fraction=0.65)
+
+    sample_0D = array(0.)
     with pytest.raises(ValueError):
-        sample_hdi(1, fraction=0.95)
+        sample_hdi(sample_0D, fraction=0.65)
+
+    sample_len1 = rng.normal(size=[1, 5])
+    with pytest.raises(ValueError):
+        sample_hdi(sample_len1, fraction=0.65)
 
 
 def test_binary_tree():

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -144,10 +144,16 @@ def test_sample_hdi_gaussian():
     sample = rng.normal(expected_mu, expected_sigma, size=[N, 3])
     intervals = sample_hdi(sample, fraction=0.9545)
     assert allclose(
-        intervals[0, :], expected_mu - 2 * expected_sigma, rtol=tolerance, atol=tolerance
+        intervals[0, :],
+        expected_mu - 2 * expected_sigma,
+        rtol=tolerance,
+        atol=tolerance,
     )
     assert allclose(
-        intervals[1, :], expected_mu + 2 * expected_sigma, rtol=tolerance, atol=tolerance
+        intervals[1, :],
+        expected_mu + 2 * expected_sigma,
+        rtol=tolerance,
+        atol=tolerance,
     )
 
 
@@ -184,7 +190,7 @@ def test_sample_hdi_invalid_shapes():
     with pytest.raises(ValueError):
         sample_hdi(sample_3D, fraction=0.65)
 
-    sample_0D = array(0.)
+    sample_0D = array(0.0)
     with pytest.raises(ValueError):
         sample_hdi(sample_0D, fraction=0.65)
 


### PR DESCRIPTION
 - Refactor of the `sample_hdi` function from `inference.pdf` to support vectorised calculation of an interval for many sets of samples of the same size.
 - `sample_hdi` no longer supports the calculation of double-intervals, and the `allow_double` keyword argument has been removed.