### PR TITLE
HMC mass matrix improvements

### DIFF
--- a/inference/mcmc/hmc/epsilon.py
+++ b/inference/mcmc/hmc/epsilon.py
@@ -1,0 +1,68 @@
+from copy import copy
+from numpy import sqrt, log
+
+
+class EpsilonSelector:
+    def __init__(self, epsilon: float):
+        # storage
+        self.epsilon = epsilon
+        self.epsilon_values = [copy(epsilon)]  # sigma values after each assessment
+        self.epsilon_checks = [0.0]  # chain locations at which sigma was assessed
+
+        # tracking variables
+        self.avg = 0
+        self.var = 0
+        self.num = 0
+
+        # settings for epsilon adjustment algorithm
+        self.accept_rate = 0.65
+        self.chk_int = 15  # interval of steps at which proposal widths are adjusted
+        self.growth_factor = 1.4  # growth factor for self.chk_int
+
+    def add_probability(self, p: float):
+        self.num += 1
+        self.avg += p
+        self.var += max(p * (1 - p), 0.03)
+
+        if self.num >= self.chk_int:
+            self.update_epsilon()
+
+    def update_epsilon(self):
+        """
+        looks at the acceptance rate of proposed steps and adjusts the epsilon
+        value to bring the acceptance rate toward its target value.
+        """
+        # normal approximation of poisson binomial distribution
+        mu = self.avg / self.num
+        std = sqrt(self.var) / self.num
+
+        # now check if the desired success rate is within 2-sigma
+        if ~(mu - 2 * std < self.accept_rate < mu + 2 * std):
+            adj = (log(self.accept_rate) / log(mu)) ** 0.15
+            adj = min(adj, 2.0)
+            adj = max(adj, 0.5)
+            self.adjust_epsilon(adj)
+        else:  # increase the check interval
+            self.chk_int = int((self.growth_factor * self.chk_int) * 0.1) * 10
+
+    def adjust_epsilon(self, ratio: float):
+        self.epsilon *= ratio
+        self.epsilon_values.append(copy(self.epsilon))
+        self.epsilon_checks.append(self.epsilon_checks[-1] + self.num)
+        self.avg = 0
+        self.var = 0
+        self.num = 0
+
+    def get_items(self):
+        return self.__dict__
+
+    def load_items(self, dictionary: dict):
+        self.epsilon = float(dictionary["epsilon"])
+        self.epsilon_values = list(dictionary["epsilon_values"])
+        self.epsilon_checks = list(dictionary["epsilon_checks"])
+        self.avg = float(dictionary["avg"])
+        self.var = float(dictionary["var"])
+        self.num = float(dictionary["num"])
+        self.accept_rate = float(dictionary["accept_rate"])
+        self.chk_int = int(dictionary["chk_int"])
+        self.growth_factor = float(dictionary["growth_factor"])

--- a/inference/mcmc/hmc/mass.py
+++ b/inference/mcmc/hmc/mass.py
@@ -1,0 +1,80 @@
+from abc import ABC, abstractmethod
+from typing import Union
+from numpy import ndarray, sqrt, eye, isscalar
+from numpy.random import Generator
+from numpy.linalg import cholesky
+from scipy.linalg import solve_triangular
+
+
+class ParticleMass(ABC):
+    inv_mass: Union[float, ndarray]
+
+    @abstractmethod
+    def get_velocity(self, r: ndarray) -> ndarray:
+        pass
+
+    @abstractmethod
+    def sample_momentum(self, rng: Generator) -> ndarray:
+        pass
+
+
+class ScalarMass(ParticleMass):
+    def __init__(self, inv_mass: float, n_parameters: int):
+        self.inv_mass = inv_mass
+        self.sqrt_mass = 1 / sqrt(self.inv_mass)
+        self.n_parameters = n_parameters
+
+    def get_velocity(self, r: ndarray) -> ndarray:
+        return r * self.inv_mass
+
+    def sample_momentum(self, rng: Generator) -> ndarray:
+        return rng.normal(size=self.n_parameters, scale=self.sqrt_mass)
+
+
+class VectorMass(ScalarMass):
+    def __init__(self, inv_mass: ndarray, n_parameters: int):
+        super().__init__(inv_mass, n_parameters)
+        assert inv_mass.ndim == 1
+        assert inv_mass.size == n_parameters
+
+
+class MatrixMass(ParticleMass):
+    def __init__(self, inv_mass: ndarray, n_parameters: int):
+        assert inv_mass.ndim == 2
+        assert inv_mass.shape[0] == inv_mass.shape[1] == n_parameters
+        assert (inv_mass == inv_mass.T).all()
+
+        self.inv_mass = inv_mass
+        self.n_parameters = n_parameters
+        # find the cholesky decomp of the mass matrix
+        iL = cholesky(inv_mass)
+        self.L = solve_triangular(iL, eye(self.n_parameters), lower=True).T
+
+    def get_velocity(self, r: ndarray) -> ndarray:
+        return self.inv_mass @ r
+
+    def sample_momentum(self, rng: Generator) -> ndarray:
+        return self.L @ rng.normal(size=self.n_parameters)
+
+
+def get_particle_mass(
+    inverse_mass: Union[float, ndarray], n_parameters: int
+) -> ParticleMass:
+    if isscalar(inverse_mass):
+        return ScalarMass(inverse_mass, n_parameters)
+
+    if not isinstance(inverse_mass, ndarray):
+        raise TypeError(
+            f"""\n
+            \r[ HamiltonianChain error ]
+            \r>> The value given to the 'inverse_mass' keyword argument must be either
+            \r>> a scalar type (e.g. int or float), or a numpy.ndarray.
+            \r>> Instead, the given value has type:
+            \r>> {type(inverse_mass)}
+            """
+        )
+
+    if inverse_mass.ndim == 1:
+        return VectorMass(inverse_mass, n_parameters)
+    else:
+        return MatrixMass(inverse_mass, n_parameters)


### PR DESCRIPTION
 - Refactored the `hmc.py` module into a sub-package.
 - Added support for non-diagonal inverse-mass matrices in `HamiltonianChain`. The `inverse_mass` keyword argument now accepts either a 1D `numpy.ndarray` of variances (to specify a diagonal covariance matrix) or a full covariance matrix as a 2D `numpy.ndarray`.